### PR TITLE
`<memory/smart_pointer>`: Change the return type of `unique_array<T>::release()`

### DIFF
--- a/src/mjxsdk/memory/smart_pointer.hpp
+++ b/src/mjxsdk/memory/smart_pointer.hpp
@@ -172,16 +172,11 @@ namespace mjx {
             return _Mysize;
         }
 
-        struct release_result {
-            pointer ptr;
-            size_t size;
-        };
-
-        release_result release() noexcept {
-            release_result _Result = {_Myptr, _Mysize};
-            _Myptr                 = nullptr;
-            _Mysize                = 0;
-            return _Result;
+        pointer release() noexcept {
+            pointer _Old_ptr = _Myptr;
+            _Myptr           = nullptr;
+            _Mysize          = 0;
+            return _Old_ptr;
         }
 
         void reset() noexcept {

--- a/tests/src/memory/unique_array/test.cpp
+++ b/tests/src/memory/unique_array/test.cpp
@@ -80,11 +80,10 @@ namespace mjx {
         constexpr size_t _Size = 512;
         int* const _Ptr        = ::mjx::create_object_array<int>(_Size);
         unique_array<int> _Unique(_Ptr, _Size);
-        const auto _Pair = _Unique.release();
+        const int* const _Released_ptr = _Unique.release();
         EXPECT_EQ(_Unique.get(), nullptr);
         EXPECT_EQ(_Unique.size(), 0);
-        EXPECT_EQ(_Pair.ptr, _Ptr);
-        EXPECT_EQ(_Pair.size, _Size);
+        EXPECT_EQ(_Released_ptr, _Ptr);
         ::mjx::delete_object_array(_Ptr, _Size);
     }
 


### PR DESCRIPTION
Fixes #37