### PR TITLE
`<memory/smart_pointer>`: Remove `reference_counter::unique()`, `shared_ptr<T>::unique()`, and `shared_array<T>::unique()`

### DIFF
--- a/src/mjxsdk/memory/smart_pointer.cpp
+++ b/src/mjxsdk/memory/smart_pointer.cpp
@@ -23,8 +23,4 @@ namespace mjx {
     long reference_counter::use_count() const noexcept {
         return _Myrefs.load(::std::memory_order_relaxed);
     }
-
-    bool reference_counter::unique() const noexcept {
-        return _Myrefs.load(::std::memory_order_relaxed) == 1;
-    }
 } // namespace mjx

--- a/src/mjxsdk/memory/smart_pointer.hpp
+++ b/src/mjxsdk/memory/smart_pointer.hpp
@@ -266,9 +266,6 @@ namespace mjx {
         // returns the number of references
         long use_count() const noexcept;
 
-        // checks whether the number of references is exactly 1
-        bool unique() const noexcept;
-
     private:
         ::std::atomic<long> _Myrefs;
     };
@@ -337,10 +334,6 @@ namespace mjx {
 
         long use_count() const noexcept {
             return _Myctr ? _Myctr->use_count() : 0;
-        }
-
-        bool unique() const noexcept {
-            return _Myctr ? _Myctr->unique() : false;
         }
 
         void reset() noexcept {
@@ -477,10 +470,6 @@ namespace mjx {
 
         long use_count() const noexcept {
             return _Myctr ? _Myctr->use_count() : 0;
-        }
-
-        bool unique() const noexcept {
-            return _Myctr ? _Myctr->unique() : false;
         }
 
         void reset() noexcept {

--- a/tests/src/memory/shared_array/test.cpp
+++ b/tests/src/memory/shared_array/test.cpp
@@ -131,19 +131,6 @@ namespace mjx {
         EXPECT_EQ(_Shared0.use_count(), 1);
     }
 
-    TEST(shared_array, unique) {
-        // test managed array uniqueness of shared_array
-        const shared_array<int> _Shared0 = ::mjx::make_shared_array<int>(4096);
-        EXPECT_TRUE(_Shared0.unique());
-        {
-            const shared_array<int> _Shared1 = _Shared0;
-            EXPECT_FALSE(_Shared0.unique());
-        }
-
-        // once _Shared1 is destroyed, _Shared0 is unique
-        EXPECT_TRUE(_Shared0.unique());
-    }
-
     TEST(shared_array, reset) {
         // test reset functionality of shared_array
         size_t _Size              = 8192;

--- a/tests/src/memory/shared_ptr/test.cpp
+++ b/tests/src/memory/shared_ptr/test.cpp
@@ -112,19 +112,6 @@ namespace mjx {
         EXPECT_EQ(_Shared0.use_count(), 1);
     }
 
-    TEST(shared_ptr, unique) {
-        // test managed object uniqueness of shared_ptr
-        const shared_ptr<int> _Shared0 = ::mjx::make_shared<int>(65536);
-        EXPECT_TRUE(_Shared0.unique());
-        {
-            const shared_ptr<int> _Shared1 = _Shared0;
-            EXPECT_FALSE(_Shared0.unique());
-        }
-    
-        // once _Shared1 is destroyed, _Shared0 is unique
-        EXPECT_TRUE(_Shared0.unique());
-    }
-
     TEST(shared_ptr, reset) {
         // test reset functionality of shared_ptr
         shared_ptr<int> _Shared = ::mjx::make_shared<int>(131072);


### PR DESCRIPTION
Fixes #38