### PR TITLE
`<memory/smart_ptr>`: Enforce `element_type` constraints in smart pointers

### DIFF
--- a/src/mjxsdk/memory/smart_pointer.hpp
+++ b/src/mjxsdk/memory/smart_pointer.hpp
@@ -13,9 +13,20 @@
 #include <utility>
 
 namespace mjx {
+    namespace mjxsdk_impl {
+        template <class _Ty>
+        concept _Valid_smart_ptr_element = !::std::is_array_v<_Ty> && requires {
+            static_cast<_Ty*>(nullptr); // must be a valid pointer type (_Ty*)
+            sizeof(_Ty); // must be a complete type (sizeof(incomplete_type) is ill-formed)
+        };
+    } // namespace mjxsdk_impl
+
     template <class _Ty>
     class unique_ptr { // smart pointer with unique object ownership semantics
     public:
+        static_assert(mjxsdk_impl::_Valid_smart_ptr_element<_Ty>,
+            "Invalid element type for unique_ptr<T>.");
+
         using element_type = _Ty;
         using pointer      = _Ty*;
 
@@ -119,6 +130,9 @@ namespace mjx {
     template <class _Ty>
     class unique_array { // smart pointer with unique object ownership semantics for arrays
     public:
+        static_assert(mjxsdk_impl::_Valid_smart_ptr_element<_Ty>,
+            "Invalid element type for unique_array<T>.");
+
         using element_type = _Ty;
         using pointer      = _Ty*;
 
@@ -273,6 +287,9 @@ namespace mjx {
     template <class _Ty>
     class shared_ptr { // smart pointer with shared object ownership semantics
     public:
+        static_assert(mjxsdk_impl::_Valid_smart_ptr_element<_Ty>,
+            "Invalid element type for shared_ptr<T>.");
+
         using element_type = _Ty;
         using pointer      = _Ty*;
 
@@ -400,6 +417,9 @@ namespace mjx {
     template <class _Ty>
     class shared_array { // smart pointer with shared object ownership semantics for arrays
     public:
+        static_assert(mjxsdk_impl::_Valid_smart_ptr_element<_Ty>,
+            "Invalid element type for shared_array<T>.");
+
         using element_type = _Ty;
         using pointer      = _Ty*;
 

--- a/tests/src/memory/shared_array/test.cpp
+++ b/tests/src/memory/shared_array/test.cpp
@@ -7,6 +7,48 @@
 #include <mjxsdk/memory/smart_pointer.hpp>
 
 namespace mjx {
+    struct _Incomplete_type;
+
+    struct _Non_empty_type {
+        int _Obj;
+
+        void _Func() const noexcept {}
+    };
+
+    TEST(shared_array, valid_element_type) {
+        // test valid element types for shared_array
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<bool>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const char>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<double(*)(void*)>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<long double(*)[]>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<int _Non_empty_type::*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void(_Non_empty_type::*)()>);
+    }
+
+    TEST(shared_array, invalid_element_type) {
+        // test invalid element types for shared_array
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<void>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<bool&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const char&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long[]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long long[4]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<float()>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<double(long double)>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<_Incomplete_type>);
+    }
+
     TEST(shared_array, null_construct) {
         // test default and null construction of shared_array
         const shared_array<int> _Shared0;

--- a/tests/src/memory/shared_ptr/test.cpp
+++ b/tests/src/memory/shared_ptr/test.cpp
@@ -7,6 +7,48 @@
 #include <mjxsdk/memory/smart_pointer.hpp>
 
 namespace mjx {
+    struct _Incomplete_type;
+
+    struct _Non_empty_type {
+        int _Obj;
+
+        void _Func() const noexcept {}
+    };
+
+    TEST(shared_ptr, valid_element_type) {
+        // test valid element types for shared_ptr
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<bool>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const char>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<double(*)(void*)>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<long double(*)[]>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<int _Non_empty_type::*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void(_Non_empty_type::*)()>);
+    }
+
+    TEST(shared_ptr, invalid_element_type) {
+        // test invalid element types for shared_ptr
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<void>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<bool&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const char&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long[]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long long[4]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<float()>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<double(long double)>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<_Incomplete_type>);
+    }
+
     TEST(shared_ptr, null_construct) {
         // test default and null construction of shared_ptr
         const shared_ptr<int> _Shared0;

--- a/tests/src/memory/unique_array/test.cpp
+++ b/tests/src/memory/unique_array/test.cpp
@@ -7,6 +7,48 @@
 #include <mjxsdk/memory/smart_pointer.hpp>
 
 namespace mjx {
+    struct _Incomplete_type;
+
+    struct _Non_empty_type {
+        int _Obj;
+
+        void _Func() const noexcept {}
+    };
+
+    TEST(unique_array, valid_element_type) {
+        // test valid element types for unique_array
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<bool>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const char>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<double(*)(void*)>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<long double(*)[]>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<int _Non_empty_type::*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void(_Non_empty_type::*)()>);
+    }
+
+    TEST(unique_array, invalid_element_type) {
+        // test invalid element types for unique_array
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<void>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<bool&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const char&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long[]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long long[4]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<float()>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<double(long double)>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<_Incomplete_type>);
+    }
+
     TEST(unique_array, null_construct) {
         // test default and null construction of unique_array
         const unique_array<int> _Unique0;

--- a/tests/src/memory/unique_ptr/test.cpp
+++ b/tests/src/memory/unique_ptr/test.cpp
@@ -7,6 +7,48 @@
 #include <mjxsdk/memory/smart_pointer.hpp>
 
 namespace mjx {
+    struct _Incomplete_type;
+
+    struct _Non_empty_type {
+        int _Obj;
+
+        void _Func() const noexcept {}
+    };
+
+    TEST(unique_ptr, valid_element_type) {
+        // test valid element types for unique_ptr
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<bool>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const char>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<volatile long long* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile float* const>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<double(*)(void*)>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<long double(*)[]>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<int _Non_empty_type::*>);
+        EXPECT_TRUE(mjxsdk_impl::_Valid_smart_ptr_element<void(_Non_empty_type::*)()>);
+    }
+
+    TEST(unique_ptr, invalid_element_type) {
+        // test invalid element types for unique_ptr
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<void>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<bool&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const char&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<volatile short&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<const volatile int&>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long[]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<long long[4]>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<float()>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<double(long double)>);
+        EXPECT_FALSE(mjxsdk_impl::_Valid_smart_ptr_element<_Incomplete_type>);
+    }
+
     TEST(unique_ptr, null_construct) {
         // test default and null construction of unique_ptr
         const unique_ptr<int> _Unique0;


### PR DESCRIPTION
Resolves #39