### PR TITLE
Use `branches-ignore` instead of `if` condition for branch filtering in CI workflows

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -6,14 +6,13 @@
 name: Build and test (Linux)
 on:
   push:
+    branches-ignore:
+      - 'main'
     paths-ignore:
       - '**/**.md'
       
 jobs:
   build-and-test:
-    # Note: As pull requests are required before merging, workflows already run during review.
-    #       Thus, 'main' branch pushes are skipped.
-    if: ${{ github.ref_name != 'main' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -6,14 +6,13 @@
 name: Build and test (Windows)
 on:
   push:
+    branches-ignore:
+      - 'main'
     paths-ignore:
       - '**/**.md'
       
 jobs:
   build-and-test:
-    # Note: As pull requests are required before merging, workflows already run during review.
-    #       Thus, 'main' branch pushes are skipped.
-    if: ${{ github.ref_name != 'main' }}
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
Implements #43