### PR TITLE
`<memory/memory_resource>`: Fix incorrect `memory_resource::const_pointer` alias

### DIFF
--- a/src/mjxsdk/memory/allocator.hpp
+++ b/src/mjxsdk/memory/allocator.hpp
@@ -23,6 +23,7 @@ namespace mjx {
         using size_type       = size_t;
         using difference_type = ptrdiff_t;
         using pointer         = void*;
+        using const_pointer   = const void*;
 
         allocator() noexcept;
         allocator(const allocator& _Other) noexcept;

--- a/src/mjxsdk/memory/impl/debug_block.hpp
+++ b/src/mjxsdk/memory/impl/debug_block.hpp
@@ -96,32 +96,22 @@ namespace mjx {
             return _Block_size - _Block_offset::_Block_padding(_User_size, _Align);
         }
 
-        inline void* _Move_ptr(void* const _Ptr, const intptr_t _Off) noexcept {
-            // moves the pointer by the given offset (forward or backward)
-            return static_cast<void*>(static_cast<unsigned char*>(_Ptr) + _Off);
-        }
-
-        inline const void* _Move_ptr(const void* const _Ptr, const intptr_t _Off) noexcept {
-            // moves the pointer by the given offset (forward or backward)
-            return static_cast<const void*>(static_cast<const unsigned char*>(_Ptr) + _Off);
-        }
-
         inline void _Fill_at(
             void* const _Dest, const size_t _Size, const intptr_t _Off, const int _Value) noexcept {
             // fills _Size bytes at (_Dest + _Off) with _Value
-            ::memset(_Move_ptr(_Dest, _Off), _Value, _Size);
+            ::memset(_Adjust_address_by_offset(_Dest, _Off), _Value, _Size);
         }
 
         inline void _Copy_dest_at(
             void* const _Dest, const void* const _Src, const size_t _Size, const size_t _Off) noexcept {
             // copies _Size bytes from _Src to (_Dest + _Off)
-            ::memcpy(_Move_ptr(_Dest, _Off), _Src, _Size);
+            ::memcpy(_Adjust_address_by_offset(_Dest, _Off), _Src, _Size);
         }
 
         inline void _Copy_src_at(
             void* const _Dest, const void* const _Src, const size_t _Size, const size_t _Off) noexcept {
             // copies _Size bytes from (_Src + _Off) to _Dest
-            ::memcpy(_Dest, _Move_ptr(_Src, _Off), _Size);
+            ::memcpy(_Dest, _Adjust_address_by_offset(_Src, _Off), _Size);
         }
 
         void* _Prepare_block(void* const _Block, const size_t _Block_size,
@@ -147,7 +137,7 @@ namespace mjx {
                 _Fill_at(_Block, _Padding, _Block_offset::_Block_padding(_User_size, _Align), 0xBF);
             }
 
-            return _Move_ptr(_Block, _Block_offset::_User_block(_Align));
+            return _Adjust_address_by_offset(_Block, _Block_offset::_User_block(_Align));
         }
 
         void _Validate_block_state(
@@ -185,7 +175,7 @@ namespace mjx {
         void* _Extract_and_validate_block(void* const _Ptr, const size_t _Size,
             const size_t _Align, const allocator_tag _Tag) noexcept {
             // extracts the original block from the user pointer and validates its metadata and integrity
-            void* const _Block    = _Move_ptr(_Ptr, -_Block_offset::_User_block(_Align));
+            void* const _Block    = _Adjust_address_by_offset(_Ptr, -_Block_offset::_User_block(_Align));
             _Block_metadata _Meta = _Extract_metadata(_Block, _Size, _Align);
             if (_Meta._Header._Size != _Size) { // report size mismatch
                 _REPORT_ERROR("Corrupted block at 0x%p. Size is %zu, but should be %zu.",

--- a/src/mjxsdk/memory/impl/utils.hpp
+++ b/src/mjxsdk/memory/impl/utils.hpp
@@ -10,14 +10,27 @@
 
 namespace mjx {
     namespace mjxsdk_impl {
-        inline void* _Adjust_address_by_offset(void* const _Address, const size_t _Off) noexcept {
-            // create a new address by moving the base address by the given offset
+        template <class _OffTy>
+        inline constexpr bool _Is_valid_offset_type = ::std::is_integral_v<_OffTy>
+            && !::std::is_same_v<_OffTy, bool>; // allows all integral types except bool
+
+        template <class _OffTy>
+        inline void* _Adjust_address_by_offset(void* const _Address, const _OffTy _Off) noexcept {
+            // returns a new address by moving the base address by the given offset
+            static_assert(_Is_valid_offset_type<_OffTy>, "_OffTy must be a non-bool integral type");
             return static_cast<void*>(static_cast<unsigned char*>(_Address) + _Off);
+        }
+
+        template <class _OffTy>
+        inline const void* _Adjust_address_by_offset(const void* const _Address, const _OffTy _Off) noexcept {
+            // returns a new address by moving the base address by the given offset
+            static_assert(_Is_valid_offset_type<_OffTy>, "_OffTy must be a non-bool integral type");
+            return static_cast<const void*>(static_cast<const unsigned char*>(_Address) + _Off);
         }
 
         inline bool _Is_within_memory_block(const void* const _Base_begin,
             const void* const _Base_end, const void* const _Block_begin, const void* const _Block_end) noexcept {
-            // check whether the memory block is within the base memory block
+            // checks whether the memory block is within the base memory block
             return _Block_begin >= _Base_begin && _Block_end <= _Base_end;
         }
 

--- a/src/mjxsdk/memory/memory_resource.hpp
+++ b/src/mjxsdk/memory/memory_resource.hpp
@@ -15,7 +15,7 @@ namespace mjx {
         using size_type       = allocator::size_type;
         using difference_type = allocator::difference_type;
         using pointer         = allocator::pointer;
-        using const_pointer   = const pointer;
+        using const_pointer   = allocator::const_pointer;
     
         memory_resource() noexcept;
         memory_resource(const memory_resource& _Other);

--- a/src/mjxsdk/memory/system_allocator.hpp
+++ b/src/mjxsdk/memory/system_allocator.hpp
@@ -16,6 +16,7 @@ namespace mjx {
         using size_type       = allocator::size_type;
         using difference_type = allocator::difference_type;
         using pointer         = allocator::pointer;
+        using const_pointer   = allocator::const_pointer;
 
         system_allocator() noexcept;
         system_allocator(const system_allocator& _Other) noexcept;

--- a/tests/src/memory/allocators_compatibility/test.cpp
+++ b/tests/src/memory/allocators_compatibility/test.cpp
@@ -51,6 +51,7 @@ namespace mjx {
         using size_type       = size_t;
         using difference_type = ptrdiff_t;
         using pointer         = void*;
+        using const_pointer   = const void*;
 
         incomp_allocator() noexcept {}
         

--- a/tests/src/memory/memory_resource/test.cpp
+++ b/tests/src/memory/memory_resource/test.cpp
@@ -94,7 +94,7 @@ namespace mjx {
         // test checking whether the resource contains a specific memory block
         constexpr size_t _Size = 8192;
         const memory_resource _Res(_Size);
-        unsigned char* const _Address = static_cast<unsigned char*>(_Res.data());
+        const unsigned char* const _Address = static_cast<const unsigned char*>(_Res.data());
         EXPECT_FALSE(_Res.contains(nullptr, 0));
         EXPECT_FALSE(_Res.contains(_Address, 0));
         EXPECT_FALSE(_Res.contains(nullptr, 2048));


### PR DESCRIPTION
Fixes #50

Additionally, replaces `_Move_ptr()` with `_Adjust_address_by_offset()` in `<memory/impl/debug_block.hpp>` for improved clarity and consistency.